### PR TITLE
Refactoring and renaming add ons to apps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ Include any relevant logs
 
 **Environment (please complete the following information):**
 
-- Add-on version: [e.g. 1.0.2]
+- App version: [e.g. 1.0.2]
 - Supervisor version: [e.g.supervisor-2021.03.6]
 - Operating system [e.g. Home Assistant OS 5.12]
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,7 +44,7 @@
     {
       "matchDatasources": ["docker"],
       "commitMessagePrefix": "⬆️",
-      "commitMessageTopic": "Addon Base Image"
+      "commitMessageTopic": "App Base Image"
     },
     {
       "matchDatasources": ["repology"],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ permissions:
   packages: read
   security-events: write
 
-
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,13 +3,19 @@ name: CI
 
 # yamllint disable-line rule:truthy
 on:
-  push:
   pull_request:
     types:
       - opened
       - reopened
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+
 jobs:
   workflows:
-    uses: casse-boubou/ha-addon-workflows/.github/workflows/addon-ci.yaml@main
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,18 +3,30 @@ name: Deploy
 
 # yamllint disable-line rule:truthy
 on:
+  push:
+    branches:
+      - main
   release:
     types:
       - published
-  workflow_run:
-    workflows: ["CI"]
-    branches: [main]
-    types:
-      - completed
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  workflows:
-    uses: casse-boubou/ha-addon-workflows/.github/workflows/addon-deploy.yaml@main
+  ci:
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main
+
+  deploy:
+    needs: ci
+    permissions:
+      contents: read
+      packages: write
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-deploy.yaml@main
     secrets:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,11 +1,14 @@
 ---
-name: Sync labels
+name: Sync Labels
 
 # yamllint disable-line rule:truthy
 on:
   schedule:
     - cron: "34 5 * * *"
   workflow_dispatch:
+
+permissions:
+  issues: write
 
 jobs:
   workflows:

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/lock.yaml@main

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -6,8 +6,11 @@ on:
   pull_request:
     types:
       - opened
+      - labeled
+      - unlabeled
       - synchronize
-  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   workflows:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/release-drafter.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/stale.yaml@main

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2025 Frosh
+Copyright (c) 2026 Frosh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: RustDesk-Server
+# Home Assistant App: RustDesk-Server
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE)
@@ -9,13 +9,13 @@
 [RustDesk-Server][rustdesk-server] permet de partager des fichiers avec d'autres de manière
 simple.
 
-[![Open your Home Assistant instance and show the add add-on repository dialog
+[![Open your Home Assistant instance and show the add app repository dialog
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
+[![Open your Home Assistant instance and show the dashboard of a Supervisor app.][add-app-shield]][add-app]
 
 ## About
 
-Cet add-on vous permet d'auto-hébergez votre propre serveur RustDesk
+Cet app vous permet d'auto-hébergez votre propre serveur RustDesk
 sur votre HomeAssistant sur RaspBerry Pi 4.
 Si vous utilisez RustDesk, vous devriez avoir votre propre server RustDesk.
 Les serveurs publics Rustdesk sont destinés à des fins de test et de recherche
@@ -31,7 +31,7 @@ extrêmement rapide... d'autres moins.
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement
 autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][hacf] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.
@@ -61,8 +61,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-[add-addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_rustdesk-server
-[add-addon-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
+[add-app]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_rustdesk-server
+[add-app-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A//github.com/casse-boubou/hassio-addons
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [releases]: https://github.com/casse-boubou/addon-rustdesk-server/releases

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![License][license-shield]](LICENSE)
 
 ![Supports aarch64 Architecture][aarch64-shield]
-![Supports i386 Architecture][i386-shield]
 
 [RustDesk-Server][rustdesk-server] permet de partager des fichiers avec d'autres de manière
 simple.
@@ -69,7 +68,6 @@ SOFTWARE.
 [releases-shield]: https://img.shields.io/github/v/release/casse-boubou/addon-rustdesk-server
 [license-shield]: https://img.shields.io/github/license/casse-boubou/addon-rustdesk-server
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [rustdesk-server]: https://github.com/rustdesk/rustdesk-server
 [discord-ha]: https://discord.gg/c5DvZ4e
 [forum]: https://community.home-assistant.io

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 MIT License
 
-Copyright (c) 2025 [Frosh][Frosh]
+Copyright (c) 2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rustdesk-server/.README.j2
+++ b/rustdesk-server/.README.j2
@@ -25,7 +25,7 @@ Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 MIT License
 
-Copyright (c) 2025 [Frosh][Frosh]
+Copyright (c) 2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rustdesk-server/.README.j2
+++ b/rustdesk-server/.README.j2
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: RustDesk-Server
+# Home Assistant App: RustDesk-Server
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]][license]
@@ -6,7 +6,7 @@
 {% set repository = namespace(url='https%3A//github.com/casse-boubou/hassio-addons', slug='c751e21a') %}
 ## About
 
-Cet add-on vous permet d'auto-hébergez votre propre serveur RustDesk sur votre HomeAssistant sur RaspBerry Pi 4.
+Cet app vous permet d'auto-hébergez votre propre serveur RustDesk sur votre HomeAssistant sur RaspBerry Pi 4.
 Si vous utilisez RustDesk, vous devriez avoir votre propre server RustDesk.
 Les serveurs publics Rustdesk sont destinés à des fins de test et de recherche et ne sont pas équipés pour gérer de grandes quantités de trafic.
 Cela signifie que le temps nécessaire pour établir une connexion via les serveurs publics peut varier considérablement et parfois même échouer si le serveur est surchargé.
@@ -15,7 +15,7 @@ De plus, si la perforation échoue un jour et que la connexion est acheminée vi
 ## Support
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][HACF] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.

--- a/rustdesk-server/DOCS.md
+++ b/rustdesk-server/DOCS.md
@@ -71,7 +71,7 @@ Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 MIT License
 
-Copyright (c) 2025 [Frosh][Frosh]
+Copyright (c) 2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rustdesk-server/DOCS.md
+++ b/rustdesk-server/DOCS.md
@@ -1,8 +1,8 @@
-# Home Assistant Add-on: RustDesk-server
+# Home Assistant App: RustDesk-server
 
 ## About
 
-Cet add-on vous permettra d'auto-hébergez votre propre serveur [RustDesk][rustdesk] sur votre
+Cet app vous permettra d'auto-hébergez votre propre serveur [RustDesk][rustdesk] sur votre
 HomeAssistant sur RaspBerry Pi 4.
 
 Si vous utilisez RustDesk, vous devriez avoir votre propre [server RustDesk][serveur_rustdesk].\
@@ -10,22 +10,22 @@ Les serveurs publics Rustdesk sont destinés à des fins de test et de recherche
 Cela signifie que le temps nécessaire pour établir une connexion via les serveurs publics peut varier considérablement et parfois même échouer si le serveur est surchargé.\
 De plus, si la perforation échoue un jour et que la connexion est acheminée via le serveur relais public... certains jours elle peut être extrêmement rapide... d'autres moins.
 
-##### _This add-on will allow you to self-host your own [RustDesk][rustdesk] server on your HomeAssistant on RaspBerry Pi 4. If you are using RustDesk you should have your own [RustDesk Server][serveur_rustdesk]. The public rustdesk servers are meant for testing and research purposes and are not equipped to handle large amounts of traffic. This means that the amount of time it takes to establish a connection through the public servers can vary drastically and sometimes even fail if the server is overloaded. Also, if hole punching ever does fail, and the connection is routed through the public Relay Server.... some days it might be blazing fast... others not so much._
+##### _This app will allow you to self-host your own [RustDesk][rustdesk] server on your HomeAssistant on RaspBerry Pi 4. If you are using RustDesk you should have your own [RustDesk Server][serveur_rustdesk]. The public rustdesk servers are meant for testing and research purposes and are not equipped to handle large amounts of traffic. This means that the amount of time it takes to establish a connection through the public servers can vary drastically and sometimes even fail if the server is overloaded. Also, if hole punching ever does fail, and the connection is routed through the public Relay Server.... some days it might be blazing fast... others not so much._
 
 ## Installation
 
-D'habord ajoutez le repertoire à l'add-on store de HomeAssistant (`https://github.com/casse-boubou/hassio-addons`):
+D'habord ajoutez le repertoire à l'app store de HomeAssistant (`https://github.com/casse-boubou/hassio-addons`):
 
-[![Open your Home Assistant instance and show the add add-on repository dialog
+[![Open your Home Assistant instance and show the add app repository dialog
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 
 Ensuite recherchez RustDesk-server dans le store et cliquez sur installer:
 
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
+[![Open your Home Assistant instance and show the dashboard of a Supervisor app.][add-app-shield]][add-app]
 
 ## Configuration
 
-Example add-on configuration:
+Example app configuration:
 
 ```yaml
 private_key: >-
@@ -61,7 +61,7 @@ Vous pouvez consulter le changelog [GitHub ici][releases].
 ## Support
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][hacf] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.
@@ -91,8 +91,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-[add-addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_rustdesk-server
-[add-addon-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
+[add-app]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_rustdesk-server
+[add-app-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fcasse-boubou%2Fhassio-addons
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [discord-ha]: https://discord.gg/c5DvZ4e

--- a/rustdesk-server/Dockerfile
+++ b/rustdesk-server/Dockerfile
@@ -16,7 +16,6 @@ RUN set -eux \
         ; \
     mkdir -p /opt; \
     if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64v8"; \
-    elif [ "${BUILD_ARCH}" = "i386" ]; then ARCH="i386"; \
     fi; \
     curl -S -J -L -o /tmp/rustdesk-server.zip \
         "https://github.com/rustdesk/rustdesk-server/releases/download/${RUSTDESK_SERVER_VERSION}/rustdesk-server-linux-${ARCH}.zip"; \

--- a/rustdesk-server/Dockerfile
+++ b/rustdesk-server/Dockerfile
@@ -47,7 +47,7 @@ LABEL \
     maintainer="Frosh" \
     org.opencontainers.image.title="${BUILD_NAME}" \
     org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
-    org.opencontainers.image.vendor="Frosh Home Assistant Add-ons" \
+    org.opencontainers.image.vendor="Frosh Home Assistant App" \
     org.opencontainers.image.authors="Frosh" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.url="https://github.com/casse-boubou/hassio-addons" \

--- a/rustdesk-server/build.yaml
+++ b/rustdesk-server/build.yaml
@@ -1,4 +1,3 @@
 ---
 build_from:
   aarch64: ghcr.io/hassio-addons/base/aarch64:18.2.1
-  i386: ghcr.io/hassio-addons/base/i386:18.2.1

--- a/rustdesk-server/config.yaml
+++ b/rustdesk-server/config.yaml
@@ -5,7 +5,6 @@ version: dev
 slug: rustdesk-server
 arch:
   - aarch64
-  - i386
 description: Rustdesk-Server pour HomeAssistant
 init: false
 map:

--- a/rustdesk-server/rootfs/etc/s6-overlay/s6-rc.d/hbbr/run
+++ b/rustdesk-server/rootfs/etc/s6-overlay/s6-rc.d/hbbr/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Add-on: RustDesk-Server
+# Home Assistant App: RustDesk-Server
 # Runs hbbr
 # ==============================================================================
 

--- a/rustdesk-server/rootfs/etc/s6-overlay/s6-rc.d/hbbs/run
+++ b/rustdesk-server/rootfs/etc/s6-overlay/s6-rc.d/hbbs/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Add-on: RustDesk-Server
+# Home Assistant App: RustDesk-Server
 # Runs hbbs
 # ==============================================================================
 

--- a/rustdesk-server/rootfs/etc/s6-overlay/s6-rc.d/key-secret/up.real
+++ b/rustdesk-server/rootfs/etc/s6-overlay/s6-rc.d/key-secret/up.real
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Add-on: RustDesk-Server
+# Home Assistant App: RustDesk-Server
 # Runs Key-secret
 # ==============================================================================
 bashio::log.info "Verifying keypair configuration"


### PR DESCRIPTION
# Changes

In version 2026.2, HA decided to rename its “add-ons” to “Apps.”
This update renames items in accordance with the new nomenclature.

https://www.home-assistant.io/blog/2026/02/04/release-20262/#add-ons-are-now-called-apps
Or github discussion
https://github.com/home-assistant/architecture/discussions/1287